### PR TITLE
Fix bug in config generation algorithm

### DIFF
--- a/src/si5351.c
+++ b/src/si5351.c
@@ -13,6 +13,7 @@ const uint32_t Si5351_MAX_DIVIDER_DENOMINATOR = 1048575;
 static uint8_t valid_omd_int(uint32_t omd) {
     switch (omd) {
         case 4:
+        case 6:
         case 8:
             return 1;
         default:

--- a/tests/test_si5351.cpp
+++ b/tests/test_si5351.cpp
@@ -45,4 +45,8 @@ TEST_F(TestSi5351, GenConf) {
     target_freq = 10.7e6;
     ASSERT_EQ(0, si5351_gen_conf(&config, target_freq));
     ASSERT_NEAR(si5351_comp_freq(&config), target_freq, SI5351_FREQ_TOL);
+
+    target_freq = 130e6;
+    ASSERT_EQ(0, si5351_gen_conf(&config, target_freq));
+    ASSERT_NEAR(si5351_comp_freq(&config), target_freq, 5);
 }


### PR DESCRIPTION
The algorithm failed to find valid configuration for syntethizable frequencies, for example 130 MHz, the OMD integer was set to an incorrect value.

It has been fixed and unittest cases added to prevent regressions in the future.